### PR TITLE
[DM-5743] Create and deploy Logstash Ansible role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ install:
   # Create ansible.cfg with correct roles_path
   - printf '[defaults]\nroles_path=../' >ansible.cfg
 
+before_script:
+    - echo localhost > inventory
+    - ansible-galaxy install --role-file requirements.yml
+
 script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ logstash-packages
 
 [![Build Status](https://travis-ci.org/lsst-sqre/ansible-logstash-packages.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-logstash-packages)
 
-Install [Logstash](https://www.elastic.co/products/logstash) using [Ansible](http://docs.ansible.com/) for LSST SQuaRE infrastructure.
+Install [Logstash](https://www.elastic.co/products/logstash) v 5.0 using [Ansible](http://docs.ansible.com/) for LSST SQuaRE infrastructure.
 
 Example Playbook
 ----------------
@@ -15,7 +15,7 @@ Example Playbook
 Version
 -------
 
-Logstash version 5.x using the [Elastic repository](https://www.elastic.co/guide/en/logstash/5.0/package-repositories.html).
+Logstash version 5.0 using the [Elastic repository](https://www.elastic.co/guide/en/logstash/5.0/package-repositories.html).
 
 Tested using Ansible 2.1 which is currently in development.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+ansible-logstash
+================
+
+[![Build Status](https://travis-ci.org/jmatt/ansible-logstash.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-logstash)
+
+Install logstash using Ansible for LSST SQuaRE infrastructure.
+
+Example Playbook
+----------------
+
+    - hosts: server
+      roles:
+         - { role: jmatt.logstash }
+
+License
+-------
+
+See the [LICENSE file](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
-ansible-logstash
-================
+logstash-packages
+=================
 
-[![Build Status](https://travis-ci.org/jmatt/ansible-logstash-packages.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-logstash-packages)
+[![Build Status](https://travis-ci.org/lsst-sqre/ansible-logstash-packages.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-logstash-packages)
 
-Install logstash using Ansible for LSST SQuaRE infrastructure.
+Install [Logstash](https://www.elastic.co/products/logstash) using [Ansible](http://docs.ansible.com/) for LSST SQuaRE infrastructure.
 
 Example Playbook
 ----------------
 
     - hosts: server
       roles:
-         - { role: jmatt.logstash.packages }
+         - { role: lsst-sqre.logstash-packages }
+
+Version
+-------
+
+Logstash version 5.x using the [Elastic repository](https://www.elastic.co/guide/en/logstash/5.0/package-repositories.html).
+
+Tested using Ansible 2.1 which is currently in development.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-logstash
 ================
 
-[![Build Status](https://travis-ci.org/jmatt/ansible-logstash.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-logstash)
+[![Build Status](https://travis-ci.org/jmatt/ansible-logstash-packages.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-logstash-packages)
 
 Install logstash using Ansible for LSST SQuaRE infrastructure.
 
@@ -10,9 +10,9 @@ Example Playbook
 
     - hosts: server
       roles:
-         - { role: jmatt.logstash }
+         - { role: jmatt.logstash.packages }
 
 License
 -------
 
-See the [LICENSE file](/LICENSE).
+The MIT License. See the [LICENSE file](https://github.com/lsst-sqre/ansible-logstash-packages/blob/master/LICENSE).

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,9 @@ galaxy_info:
   #  - squeeze
   #  - wheezy
   galaxy_tags:
-    - system
+    - centos
+    - elastic
     - monitoring
+    - system
+    - ubuntu
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: J. Matt Peterson
-  description: LSST SQuaRE's Logstash deploy.
+  description: Logstash v 5.0 for LSST SQuaRE.
   company: LSST SQuaRE
   issue_tracker_url: https://github.com/lsst-sqre/ansible-logstash-packages/issues
   license: MIT
@@ -27,4 +27,5 @@ galaxy_info:
     - monitoring
     - system
     - ubuntu
-dependencies: []
+dependencies:
+  - role: jmatt.java-packages

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,27 @@
+galaxy_info:
+  author: J. Matt Peterson
+  description: LSST SQuaRE's Logstash deploy.
+  company: LSST SQuaRE
+  issue_tracker_url: https://github.com/lsst-sqre/ansible-logstash-packages/issues
+  license: MIT
+  min_ansible_version: 2.1
+  platforms:
+  - name: EL
+    versions:
+      - 7
+  - name: Ubuntu
+    versions:
+      - trusty
+      - xenial
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - squeeze
+  #  - wheezy
+  galaxy_tags:
+    - system
+    - monitoring
+dependencies: []

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,1 @@
+- src: jmatt.java-packages

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,0 +1,17 @@
+---
+# Install Logstash packages on debian based distributions.
+
+- name: Add Logstash apt key.
+  apt_key: url=https://packages.elastic.co/GPG-KEY-elasticsearch state=present
+
+- name: Install apt-transport-https dependency.
+  apt: name=apt-transport-https update_cache=yes state=latest install_recommends=no
+
+- name: Install Logstash repository.
+  apt_repository: repo='deb http://packages.elastic.co/logstash/5.0/debian stable main' state=present
+
+- name: Install Logstash package.
+  apt: name=logstash update_cache=yes state=latest install_recommends=no
+
+- name: Configure Logstash.
+  include: logstash.yml

--- a/tasks/logstash.yml
+++ b/tasks/logstash.yml
@@ -1,0 +1,5 @@
+---
+# Configure the Logstash service.
+
+- name: Start the Logstash service.
+  service: name=logstash state=started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# tasks file for logstash-packages
+
+- name: Stop the Logstash service.
+  service: name=logstash state=stopped
+  ignore_errors: true
+
+- include: redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: debian.yml
+  when: ansible_os_family == 'Debian'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,14 @@
+---
+# Install Logstash packages on redhat base distributions.
+
+- name: Add the Logstash RPM key.
+  rpm_key: state=present key=https://packages.elastic.co/GPG-KEY-elasticsearch
+
+- name: Add the Logstash repository.
+  yum_repository:
+    name: Logstash-repository
+    description: Logstash repository for 5.x packages.
+    baseurl: http://packages.elastic.co/logstash/5.0/centos
+    gpgcheck: yes
+    enabled: yes
+    file: logstash

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-logstash-packages


### PR DESCRIPTION
Create and deploy Logstash, Fluentd and Riemann Ansible roles for LSST SQuaRE infrastructure.
- [x] Install Logstash 5.x using the Elastic repository.
- [x] Verify using travis.ci.
- [x] Available as Ansible Galaxy role `lsst-sqre.logstash-packages`. After PR is accepted and Ansible Galaxy is updated.
